### PR TITLE
Parallelized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+rayon = "1.5"
 num-bigint = "0.4"
 fastrand = "1.4.0"
 num-traits = "0.2.14"

--- a/examples/primes.rs
+++ b/examples/primes.rs
@@ -1,15 +1,20 @@
 use libcm;
-use std::time::{Duration, Instant};
+use std::time::Instant;
+use rayon::prelude::*;
 
 fn main() {
-    let mut primes: Vec<u64> = Vec::new();
     let start = Instant::now();
-    for x in 3..100_000 {
-        if let Some(x) = libcm::miller_rabin(x as u64) {
-            primes.push(x);
-        }
-    }
-    println!("we got count: {:?} primes", primes.len());
+    let prime_count = count_primes(100_000);
     let end = start.elapsed().as_secs();
+    println!("we got count: {:?} primes", prime_count);
     println!("runtime {:?}", &end);
+}
+
+fn count_primes (limit: u64) -> u64 {
+    (3..limit).into_par_iter()
+    .filter(|i| match libcm::miller_rabin(*i) {
+        Some(_) => true,
+        None => false
+    })
+    .count() as u64
 }


### PR DESCRIPTION
Updated primes example to run in parallel with rayon. Time elapsed went from 75 to 16 seconds on my Macbook Air M1.